### PR TITLE
Add warning for incorrect battery values and fix syntax error

### DIFF
--- a/src/sot/_disk.py
+++ b/src/sot/_disk.py
@@ -162,9 +162,9 @@ class Disk(Widget):
                 style = "dark_orange"
 
             table.add_row(
-                f"[b]Free:[/] {sizeof_fmt(du.free, fmt=".1f")}",
-                f"[b]Used:[/] {sizeof_fmt(du.used, fmt=".1f")}",
-                f"[b]Total:[/] {sizeof_fmt(du.total, fmt=".1f")}",
+                f"[b]Free:[/] {sizeof_fmt(du.free, fmt='.1f')}",
+                f"[b]Used:[/] {sizeof_fmt(du.used, fmt='.1f')}",
+                f"[b]Total:[/] {sizeof_fmt(du.total, fmt='.1f')}",
                 f"[b]🍕[/] {du.percent:.1f}%",
                 style=style,
             )

--- a/src/sot/_info.py
+++ b/src/sot/_info.py
@@ -60,6 +60,9 @@ class InfoLine(Widget):
             elif bat.percent < 20:
                 bat_string = "🔋 [yellow]" + bat_string + "[/]"
 
+            # The battery percentage may report invalid values due to 
+            # hardware or system inaccuracies. These values are
+            # displayed with a warning to alert users to the anomaly.
             if bat.percent < 0 or bat.percent > 100:
                 bat_string = "[red3 reverse bold]⚠ [/] " + bat_string
 

--- a/src/sot/_info.py
+++ b/src/sot/_info.py
@@ -59,6 +59,10 @@ class InfoLine(Widget):
                 bat_string = "🪫 [slate_blue1]" + bat_string + "[/]"
             elif bat.percent < 20:
                 bat_string = "🔋 [yellow]" + bat_string + "[/]"
+
+            if bat.percent < 0 or bat.percent > 100:
+                bat_string = "[red3 reverse bold]⚠ [/] " + bat_string
+
             right.append(bat_string)
 
         table = Table(show_header=False, expand=True, box=None, padding=0)


### PR DESCRIPTION
- I couldn't find any reasons why the battery value would exceed its limits, except for potential anomalies or hardware issues. So, I just added logic to display a warning if the battery percentage is lower than 0 or higher than 100.
![Screenshot_20250108_200819](https://github.com/user-attachments/assets/8d332411-9b06-4af1-beb0-3fd5b523c688)
- Fixed a syntax error.