### PR TITLE
Fix `setuptools` package discovery

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft src
+global-exclude __pycache__ *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
 [tool.setuptools.dynamic]
 version = { attr = "sot.__about__.__version__" }
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project.urls]
 Code = "https://github.com/anistark/sot"
 Issues = "https://github.com/anistark/sot/issues"
@@ -46,7 +49,3 @@ Documentation = "https://github.com/anistark/sot#readme"
 
 [project.scripts]
 sot = "sot._app:run"
-
-[tool.setuptools]
-packages = ["sot"]
-package-dir = { "" = "src" }


### PR DESCRIPTION
In `src/` layouts, `setuptools` automatically discovers packages under `src/<package_name>`, but if you specify both `tool.setuptools.packages` and `tool.setuptools.package-dir`, then `packages` must have a list of all subpackages inside `tool.setuptools.package-dir`. This PR removes `tool.setuptools.packages` in favour of `tool.setuptools.packages.find` so that we can rely on automated discovery mechanisms.

I also introduced a [`MANIFEST.in`](https://setuptools.pypa.io/en/stable/userguide/miscellaneous.html) file here as I noticed that the `__pycache__` files in the installation were being included.

Switching to `hatchling` would provide better defaults; please let me know if you desire it and I can open a follow-up PR.

Closes #15 