### PR TITLE
feat: add live GPU monitoring widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-...
+### Added
+- **GPU Monitoring Widget** - Live GPU statistics now appear in the main `sot` dashboard:
+  - Real-time utilization history graph with current percentage
+  - Memory usage (used/total on NVIDIA; in-use and allocated on Apple Silicon's unified memory)
+  - Temperature and power draw where the platform exposes them
+  - Renderer/Tiler utilization breakdown and GPU core count on Apple Silicon
+  - Cross-platform detection: Apple Silicon via `ioreg` (no sudo required), NVIDIA via `nvidia-smi`, AMD via `rocm-smi` (best effort)
+  - Falls back to the decorative animation when no GPU is detected
+  - No new runtime dependencies
 
 ## [6.0.1](https://github.com/anistark/sot/releases/tag/v6.0.1) - 2026-01-18
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,17 @@ sot
   - Used
   - Swap
 
+### GPU
+
+- **Live GPU Widget** - Real-time GPU stats in the main dashboard (shown automatically when a GPU is detected)
+  - Utilization history graph with current percentage
+  - Memory usage (used/total, or in-use/allocated on unified-memory systems)
+  - Temperature and power draw, when exposed by the platform
+- Cross-platform detection
+  - **Apple Silicon** (via `ioreg`, no sudo): utilization, memory, renderer/tiler breakdown, core count
+  - **NVIDIA** (via `nvidia-smi`): utilization, memory, temperature, power
+  - **AMD** (via `rocm-smi`): best-effort
+
 ### Network
 
 - Local IP

--- a/src/sot/_app.py
+++ b/src/sot/_app.py
@@ -13,9 +13,11 @@ from textual.app import App, ComposeResult
 from textual.widgets import Header
 
 from .__about__ import __current_year__, __version__
+from ._gpu import has_gpu
 from .widgets import (
     CPUWidget,
     DiskWidget,
+    GpuWidget,
     HealthScoreWidget,
     InfoWidget,
     MemoryWidget,
@@ -125,14 +127,21 @@ class SotApp(App):
         procs_list.id = "procs-list"
         yield procs_list
 
-        # Row 3: Memory, Sot Widget (Process List continues)
+        # Row 3: Memory, GPU/Sot Widget (Process List continues)
         mem_widget = MemoryWidget()
         mem_widget.id = "mem-widget"
         yield mem_widget
 
-        sot_widget = SotWidget()
-        sot_widget.id = "sot-widget"
-        yield sot_widget
+        # Show live GPU stats when a GPU is detected; otherwise keep the
+        # decorative SOT animation in this slot.
+        if has_gpu():
+            gpu_widget = GpuWidget()
+            gpu_widget.id = "gpu-widget"
+            yield gpu_widget
+        else:
+            sot_widget = SotWidget()
+            sot_widget.id = "sot-widget"
+            yield sot_widget
 
         # Row 4: Disk, Network Connections, Network Widget
         disk_widget = DiskWidget(self.disk_mountpoint)

--- a/src/sot/_gpu.py
+++ b/src/sot/_gpu.py
@@ -1,0 +1,299 @@
+"""
+GPU data collection.
+
+Cross-platform GPU detection and sampling with graceful degradation. Each backend
+returns whatever metrics the platform exposes and leaves the rest as ``None`` so the
+widget can render only what is actually available. Collection never raises.
+
+Backends (probed in order, first match wins):
+    * Apple Silicon - ``ioreg`` IOAccelerator statistics (no sudo required)
+    * NVIDIA        - ``nvidia-smi`` CSV query
+    * AMD           - ``rocm-smi`` JSON (best effort)
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Callable, Optional
+
+# A GPU reader returns a sample, or ``None`` when it cannot read anything.
+Reader = Callable[[], Optional["GpuSample"]]
+
+_SUBPROCESS_TIMEOUT = 3.0
+
+
+@dataclass
+class GpuSample:
+    """A single point-in-time GPU reading. Every metric is optional.
+
+    Memory values are in bytes; ``mem_total`` is ``None`` on unified-memory
+    architectures (e.g. Apple Silicon) where there is no dedicated VRAM.
+    ``name`` and ``cores`` describe the device rather than its live state.
+    """
+
+    name: Optional[str] = None
+    util_percent: Optional[float] = None
+    mem_used: Optional[int] = None
+    mem_total: Optional[int] = None
+    mem_alloc: Optional[int] = None
+    temp_c: Optional[float] = None
+    power_w: Optional[float] = None
+    cores: Optional[int] = None
+    renderer_util_percent: Optional[float] = None
+    tiler_util_percent: Optional[float] = None
+
+    def is_empty(self) -> bool:
+        """True when no live metric could be read (an unusable sample).
+
+        Device identity (``name``, ``cores``) is ignored here - a sample with
+        only a name is still useless for display.
+        """
+        return all(
+            value is None
+            for value in (
+                self.util_percent,
+                self.mem_used,
+                self.mem_total,
+                self.mem_alloc,
+                self.temp_c,
+                self.power_w,
+                self.renderer_util_percent,
+                self.tiler_util_percent,
+            )
+        )
+
+
+def _run(cmd: list[str]) -> Optional[str]:
+    """Run a command and return stdout, or ``None`` on any failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _to_float(value: Optional[str]) -> Optional[float]:
+    """Parse a float, tolerating ``None``, blanks, and ``[N/A]`` placeholders."""
+    if value is None:
+        return None
+    try:
+        return float(value.strip())
+    except (AttributeError, ValueError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Apple Silicon
+# --------------------------------------------------------------------------- #
+
+_APPLE_UTIL_RE = re.compile(r'"Device Utilization %"=(\d+)')
+_APPLE_RENDER_RE = re.compile(r'"Renderer Utilization %"=(\d+)')
+_APPLE_TILER_RE = re.compile(r'"Tiler Utilization %"=(\d+)')
+_APPLE_MEM_RE = re.compile(r'"In use system memory"=(\d+)')
+_APPLE_ALLOC_RE = re.compile(r'"Alloc system memory"=(\d+)')
+_APPLE_CORES_RE = re.compile(r'"gpu-core-count"\s*=\s*(\d+)')
+
+
+def _is_apple_silicon() -> bool:
+    return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+
+@lru_cache(maxsize=1)
+def _apple_gpu_name() -> Optional[str]:
+    """Chip brand string (e.g. ``Apple M1 Pro``); the GPU is part of the SoC."""
+    stdout = _run(["sysctl", "-n", "machdep.cpu.brand_string"])
+    if stdout is None:
+        return None
+    name = stdout.strip()
+    return name or None
+
+
+def _search_int(pattern: re.Pattern, text: str) -> Optional[int]:
+    match = pattern.search(text)
+    return int(match.group(1)) if match else None
+
+
+def _parse_apple_ioreg(text: str) -> Optional[GpuSample]:
+    """Parse ``ioreg -c IOAccelerator`` output into a sample (pure)."""
+    util = _search_int(_APPLE_UTIL_RE, text)
+    mem_used = _search_int(_APPLE_MEM_RE, text)
+    if util is None and mem_used is None:
+        return None
+
+    render = _search_int(_APPLE_RENDER_RE, text)
+    tiler = _search_int(_APPLE_TILER_RE, text)
+    return GpuSample(
+        name=_apple_gpu_name(),
+        util_percent=float(util) if util is not None else None,
+        # Unified memory: in-use and allocated sizes are known, but there is no
+        # dedicated VRAM total to report.
+        mem_used=mem_used,
+        mem_total=None,
+        mem_alloc=_search_int(_APPLE_ALLOC_RE, text),
+        cores=_search_int(_APPLE_CORES_RE, text),
+        renderer_util_percent=float(render) if render is not None else None,
+        tiler_util_percent=float(tiler) if tiler is not None else None,
+    )
+
+
+def _read_apple_silicon() -> Optional[GpuSample]:
+    stdout = _run(["ioreg", "-r", "-d", "1", "-w", "0", "-c", "IOAccelerator"])
+    if stdout is None:
+        return None
+    return _parse_apple_ioreg(stdout)
+
+
+# --------------------------------------------------------------------------- #
+# NVIDIA
+# --------------------------------------------------------------------------- #
+
+_NVIDIA_QUERY = (
+    "name,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw"
+)
+_MIB = 1024 * 1024
+
+
+def _parse_nvidia_csv(text: str) -> Optional[GpuSample]:
+    """Parse one row of ``nvidia-smi --format=csv,noheader,nounits`` (pure)."""
+    rows = [row for row in text.splitlines() if row.strip()]
+    if not rows:
+        return None
+    # Report the first GPU only for now.
+    fields = [field.strip() for field in rows[0].split(",")]
+    if len(fields) < 6:
+        return None
+
+    name, util, mem_used, mem_total, temp, power = fields[:6]
+    mem_used_mib = _to_float(mem_used)
+    mem_total_mib = _to_float(mem_total)
+    return GpuSample(
+        name=name or None,
+        util_percent=_to_float(util),
+        mem_used=int(mem_used_mib * _MIB) if mem_used_mib is not None else None,
+        mem_total=int(mem_total_mib * _MIB) if mem_total_mib is not None else None,
+        temp_c=_to_float(temp),
+        power_w=_to_float(power),
+    )
+
+
+def _read_nvidia() -> Optional[GpuSample]:
+    stdout = _run(
+        [
+            "nvidia-smi",
+            f"--query-gpu={_NVIDIA_QUERY}",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    if stdout is None:
+        return None
+    return _parse_nvidia_csv(stdout)
+
+
+# --------------------------------------------------------------------------- #
+# AMD (best effort)
+# --------------------------------------------------------------------------- #
+
+
+def _find_first(card: dict, *needles: str) -> Optional[str]:
+    """Return the value of the first key containing all the given substrings.
+
+    ``rocm-smi`` key names vary across versions, so match loosely.
+    """
+    for key, value in card.items():
+        lowered = key.lower()
+        if all(needle in lowered for needle in needles):
+            return value
+    return None
+
+
+def _parse_amd_json(text: str) -> Optional[GpuSample]:
+    """Parse ``rocm-smi --json`` output into a sample (pure, best effort)."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    cards = [value for key, value in data.items() if isinstance(value, dict)]
+    if not cards:
+        return None
+    card = cards[0]
+
+    mem_used = _to_float(_find_first(card, "vram", "used"))
+    mem_total = _to_float(_find_first(card, "vram", "total"))
+    sample = GpuSample(
+        name=_find_first(card, "card series") or _find_first(card, "card model"),
+        util_percent=_to_float(_find_first(card, "gpu use")),
+        mem_used=int(mem_used) if mem_used is not None else None,
+        mem_total=int(mem_total) if mem_total is not None else None,
+        temp_c=_to_float(_find_first(card, "temperature", "edge")),
+        power_w=_to_float(_find_first(card, "average graphics package power")),
+    )
+    return None if sample.is_empty() else sample
+
+
+def _read_amd() -> Optional[GpuSample]:
+    stdout = _run(
+        [
+            "rocm-smi",
+            "--showuse",
+            "--showmeminfo",
+            "vram",
+            "--showtemp",
+            "--showpower",
+            "--json",
+        ]
+    )
+    if stdout is None:
+        return None
+    return _parse_amd_json(stdout)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+@lru_cache(maxsize=1)
+def _select_reader() -> Optional[Reader]:
+    """Probe available backends once and remember the first that returns data."""
+    candidates: list[Reader] = []
+    if _is_apple_silicon():
+        candidates.append(_read_apple_silicon)
+    if shutil.which("nvidia-smi"):
+        candidates.append(_read_nvidia)
+    if shutil.which("rocm-smi"):
+        candidates.append(_read_amd)
+
+    for reader in candidates:
+        sample = reader()
+        if sample is not None and not sample.is_empty():
+            return reader
+    return None
+
+
+def has_gpu() -> bool:
+    """Whether a readable GPU is available on this machine."""
+    return _select_reader() is not None
+
+
+def read_gpu() -> Optional[GpuSample]:
+    """Return a current GPU sample, or ``None`` when no GPU is available."""
+    reader = _select_reader()
+    if reader is None:
+        return None
+    return reader()

--- a/src/sot/widgets/__init__.py
+++ b/src/sot/widgets/__init__.py
@@ -8,6 +8,7 @@ Each widget is responsible for displaying specific system information.
 from .base_widget import BaseWidget
 from .cpu import CPUWidget
 from .disk import DiskWidget
+from .gpu import GpuWidget
 from .health_score import HealthScoreWidget
 from .info import InfoWidget
 from .memory import MemoryWidget
@@ -20,6 +21,7 @@ __all__ = [
     "BaseWidget",
     "CPUWidget",
     "DiskWidget",
+    "GpuWidget",
     "HealthScoreWidget",
     "InfoWidget",
     "SotWidget",

--- a/src/sot/widgets/gpu.py
+++ b/src/sot/widgets/gpu.py
@@ -1,0 +1,108 @@
+"""
+GPU Widget
+
+Displays real-time GPU utilization with a history graph, plus memory, temperature,
+power draw, and a utilization breakdown when the platform exposes them. Only the
+metrics that are actually available are shown.
+"""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.text import Text
+
+from .._gpu import GpuSample, read_gpu
+from .._helpers import sizeof_fmt
+from ..braille_stream import BrailleStream
+from .base_widget import BaseWidget
+
+# Initial graph size; widths are recomputed on resize.
+_GRAPH_WIDTH = 20
+_GRAPH_HEIGHT = 6
+_LABEL_WIDTH = 7
+
+
+def _metric_line(label: str, value: str, color: str) -> Text:
+    """Render a single ``label   value`` metric row with an aligned label."""
+    line = Text()
+    line.append(f"{label:<{_LABEL_WIDTH}}", style="bright_white")
+    line.append(value, style=color)
+    return line
+
+
+class GpuWidget(BaseWidget):
+    """GPU widget showing utilization, memory, temperature, and power."""
+
+    def __init__(self, **kwargs):
+        super().__init__(title="GPU", **kwargs)
+
+    def on_mount(self):
+        self.util_stream = BrailleStream(_GRAPH_WIDTH, _GRAPH_HEIGHT, 0.0, 100.0)
+
+        sample = read_gpu()
+        if sample is not None and sample.name:
+            title = f"[b]GPU[/] - {sample.name}"
+            if sample.cores:
+                title += f" · {sample.cores} cores"
+            self.panel.title = title
+
+        self.collect_data()
+        self.set_interval(2.0, self.collect_data)
+
+    def _memory_text(self, sample: GpuSample) -> str:
+        used = sizeof_fmt(sample.mem_used, fmt=".1f")
+        if sample.mem_total:
+            return f"{used} / {sizeof_fmt(sample.mem_total, fmt='.1f')}"
+        return used
+
+    def _metric_rows(self, sample: GpuSample) -> list[Text]:
+        """Build a metric row per available reading (skips anything missing)."""
+        rows: list[Text] = []
+        if sample.mem_used is not None:
+            rows.append(_metric_line("Mem", self._memory_text(sample), "sky_blue3"))
+        if sample.mem_alloc is not None:
+            rows.append(
+                _metric_line("Alloc", sizeof_fmt(sample.mem_alloc, fmt=".1f"), "cyan")
+            )
+        if sample.temp_c is not None:
+            rows.append(
+                _metric_line("Temp", f"{round(sample.temp_c)}°C", "slate_blue1")
+            )
+        if sample.power_w is not None:
+            rows.append(_metric_line("Power", f"{sample.power_w:.0f} W", "aquamarine3"))
+        if sample.renderer_util_percent is not None:
+            rows.append(
+                _metric_line(
+                    "Render", f"{round(sample.renderer_util_percent)}%", "yellow"
+                )
+            )
+        if sample.tiler_util_percent is not None:
+            rows.append(
+                _metric_line(
+                    "Tiler", f"{round(sample.tiler_util_percent)}%", "dark_orange"
+                )
+            )
+        return rows
+
+    def _util_graph(self, sample: GpuSample) -> Text:
+        # Fall back to 0 so the history keeps scrolling even if util is missing.
+        self.util_stream.add_value(sample.util_percent or 0.0)
+        lines = self.util_stream.graph
+        if sample.util_percent is not None:
+            value_str = f"{sample.util_percent:5.1f}%"
+            if len(lines[0]) >= len(value_str):
+                lines = [lines[0][: -len(value_str)] + value_str] + lines[1:]
+        return Text.from_markup("[yellow]" + "\n".join(lines) + "[/]")
+
+    def collect_data(self):
+        sample = read_gpu()
+        if sample is None:
+            self.update_panel_content(Text("No GPU data available", style="dim"))
+            return
+
+        graph = self._util_graph(sample)
+        self.update_panel_content(Group(graph, Text(""), *self._metric_rows(sample)))
+
+    async def on_resize(self, event):
+        graph_width = max(10, self.size.width - 4)
+        self.util_stream.reset_width(graph_width)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,103 @@
+from sot import _gpu
+
+
+def test_parse_apple_ioreg():
+    # Trimmed real output from `ioreg -c IOAccelerator` on Apple Silicon.
+    text = (
+        '"gpu-core-count" = 14\n'
+        '"PerformanceStatistics" = {"In use system memory (driver)"=0,'
+        '"Alloc system memory"=2453848064,"Tiler Utilization %"=21,'
+        '"Renderer Utilization %"=20,"Device Utilization %"=37,'
+        '"In use system memory"=344702976}'
+    )
+    sample = _gpu._parse_apple_ioreg(text)
+    assert sample is not None
+    assert sample.util_percent == 37.0
+    assert sample.mem_used == 344702976
+    # Unified memory has no dedicated VRAM total.
+    assert sample.mem_total is None
+    assert sample.mem_alloc == 2453848064
+    assert sample.cores == 14
+    assert sample.renderer_util_percent == 20.0
+    assert sample.tiler_util_percent == 21.0
+
+
+def test_parse_apple_ioreg_ignores_driver_memory():
+    # The "(driver)" variant must not be mistaken for in-use memory.
+    text = '"In use system memory (driver)"=0,"In use system memory"=512'
+    sample = _gpu._parse_apple_ioreg(text)
+    assert sample is not None
+    assert sample.mem_used == 512
+
+
+def test_parse_apple_ioreg_no_match():
+    assert _gpu._parse_apple_ioreg("nothing useful here") is None
+
+
+def test_parse_nvidia_csv():
+    text = "NVIDIA GeForce RTX 4090, 42, 1024, 24576, 55, 120.5\n"
+    sample = _gpu._parse_nvidia_csv(text)
+    assert sample is not None
+    assert sample.name == "NVIDIA GeForce RTX 4090"
+    assert sample.util_percent == 42.0
+    assert sample.mem_used == 1024 * 1024 * 1024
+    assert sample.mem_total == 24576 * 1024 * 1024
+    assert sample.temp_c == 55.0
+    assert sample.power_w == 120.5
+
+
+def test_parse_nvidia_csv_handles_na():
+    # Power draw is unavailable on some cards and reported as [N/A].
+    text = "Tesla T4, 0, 0, 15360, 30, [N/A]"
+    sample = _gpu._parse_nvidia_csv(text)
+    assert sample is not None
+    assert sample.power_w is None
+    assert sample.util_percent == 0.0
+
+
+def test_parse_nvidia_csv_first_gpu_only():
+    text = "GPU-0, 10, 100, 8192, 40, 50\nGPU-1, 90, 200, 8192, 70, 90\n"
+    sample = _gpu._parse_nvidia_csv(text)
+    assert sample is not None
+    assert sample.name == "GPU-0"
+    assert sample.util_percent == 10.0
+
+
+def test_parse_nvidia_csv_empty():
+    assert _gpu._parse_nvidia_csv("") is None
+
+
+def test_parse_amd_json():
+    text = (
+        '{"card0": {"GPU use (%)": "73", '
+        '"VRAM Total Memory (B)": "17163091968", '
+        '"VRAM Total Used Memory (B)": "1234567", '
+        '"Temperature (Sensor edge) (C)": "61.0", '
+        '"Average Graphics Package Power (W)": "95.0", '
+        '"Card Series": "Radeon RX 7900 XTX"}}'
+    )
+    sample = _gpu._parse_amd_json(text)
+    assert sample is not None
+    assert sample.util_percent == 73.0
+    assert sample.mem_total == 17163091968
+    assert sample.mem_used == 1234567
+    assert sample.temp_c == 61.0
+    assert sample.power_w == 95.0
+    assert sample.name == "Radeon RX 7900 XTX"
+
+
+def test_parse_amd_json_invalid():
+    assert _gpu._parse_amd_json("not json") is None
+
+
+def test_gpu_sample_is_empty():
+    assert _gpu.GpuSample().is_empty()
+    assert not _gpu.GpuSample(util_percent=0.0).is_empty()
+
+
+def test_to_float():
+    assert _gpu._to_float("12.5") == 12.5
+    assert _gpu._to_float(" 7 ") == 7.0
+    assert _gpu._to_float("[N/A]") is None
+    assert _gpu._to_float(None) is None
+    assert _gpu._to_float("") is None


### PR DESCRIPTION
The main dashboard showed GPU details only statically via `sot info`, while peers (btop, bottom, glances, nvtop) all surface live GPU stats. Add a real-time GPU widget that takes over the previously decorative SOT slot and falls back to that animation when no GPU is present.

The widget shows a utilization history graph plus whichever metrics the platform exposes, so nothing renders as a blank or zero placeholder:

  - Apple Silicon: utilization, in-use/allocated memory, renderer and tiler breakdown, and core count, all read from `ioreg` without sudo
  - NVIDIA: utilization, memory used/total, temperature, and power draw via `nvidia-smi`
  - AMD: best-effort via `rocm-smi`

Detection probes backends once and caches the result; collection never raises and degrades to whatever is available. No new runtime dependencies are added — backends shell out to existing system tools.

Parsing is split into pure functions covered by unit tests, so the CSV and ioreg formats are verified without requiring GPU hardware.