### PR TITLE
feat(clean): add coding agent caches to sot clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.1.0](https://github.com/anistark/sot/releases/tag/v6.1.0) - 2026-08-05
 
 ### Added
 - **GPU Monitoring Widget** - Live GPU statistics now appear in the main `sot` dashboard:
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cross-platform detection: Apple Silicon via `ioreg` (no sudo required), NVIDIA via `nvidia-smi`, AMD via `rocm-smi` (best effort)
   - Falls back to the decorative animation when no GPU is detected
   - No new runtime dependencies
+- **macOS Install Data cleaning** - `sot clean` now reports the leftover macOS installer payload, routinely 10GB+ on machines that have taken a system update
+  - Covers both the data volume path and the pre-Catalina root path
+  - Marked as requiring sudo; the SIP protected `Locked Files` stub inside is skipped with a warning
+
+### Fixed
+- **`sot clean` under sudo** - Targets marked as requiring sudo were skipped unconditionally, so `sudo sot clean` never cleaned them despite the summary saying it would
+  - The skip now checks for actual elevation, making `Temp Files`, `System Logs` and `macOS Install Data` reclaimable
+  - Running elevated is called out in the header, and the summary no longer reports those targets as "will be skipped"
 
 ## [6.0.1](https://github.com/anistark/sot/releases/tag/v6.0.1) - 2026-01-18
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ The clean command intelligently detects your operating system and cleans platfor
 - Python pip cache
 - npm cache
 - Trash bin
+- Coding agent caches (Claude Code, pi, opencode, Kilo Code)
 
 **Linux:**
 - User cache (`~/.cache`)
@@ -401,6 +402,7 @@ The clean command intelligently detects your operating system and cleans platfor
 - Browser caches
 - Python pip cache
 - npm cache
+- Coding agent caches (Claude Code, pi, opencode, Kilo Code)
 
 **Windows:**
 - User temporary files (`%TEMP%`)
@@ -409,6 +411,33 @@ The clean command intelligently detects your operating system and cleans platfor
 - Browser caches
 - Python pip cache
 - npm cache
+- Coding agent caches (Claude Code, pi, opencode, Kilo Code)
+
+### Coding Agent Caches
+
+Agents are only listed when they're actually installed, so the table stays limited to what's on your machine. Only caches, logs and scratch directories are touched. Conversation history, sessions, credentials and config are left alone.
+
+| Agent | Cleaned |
+| ----- | ------- |
+| Claude Code | `~/.claude/{cache,paste-cache,debug,shell-snapshots,session-env,statsig}`, `~/.cache/claude`, `~/Library/Caches/claude-cli-nodejs` |
+| pi | `~/.pi/{cache,logs}`, `~/.cache/pi` |
+| opencode | `~/.cache/opencode`, `~/.local/share/opencode/{cache,log}` |
+| Kilo Code | `~/.kilocode/cache`, plus `kilocode.kilo-code/{cache,checkpoints}` under the VS Code, Cursor and VSCodium global storage directories |
+
+Notably left alone: `~/.claude/projects` (session transcripts that `claude --resume` reads) and `~/.local/share/claude/versions` (the installed binaries).
+
+If you've relocated a cache directory, `sot` picks it up from the environment rather than assuming the default. Exported variables are read from the shell you run `sot` in:
+
+| Variable | Overrides |
+| -------- | --------- |
+| `CLAUDE_CONFIG_DIR` | `~/.claude` |
+| `XDG_CACHE_HOME` | `~/.cache` |
+| `XDG_DATA_HOME` | `~/.local/share` |
+| `XDG_CONFIG_HOME` | `~/.config` |
+| `APPDATA` / `LOCALAPPDATA` | `~/AppData/Roaming`, `~/AppData/Local` |
+| `VSCODE_PORTABLE` | VS Code portable-mode user data (no default; paths are skipped when unset) |
+
+Use `sot clean --dry-run` to confirm the resolved locations before deleting anything.
 
 ### Permissions
 

--- a/man/sot.1
+++ b/man/sot.1
@@ -148,6 +148,8 @@ Remove temporary files
 .IP \(bu 2
 Clear application logs and crash reports
 .IP \(bu 2
+Clear coding agent caches (Claude Code, pi, opencode, Kilo Code)
+.IP \(bu 2
 Dry-run mode to preview changes
 .IP \(bu 2
 macOS-specific cleaning (Xcode, Homebrew, etc.)

--- a/src/sot/__about__.py
+++ b/src/sot/__about__.py
@@ -1,4 +1,4 @@
 from datetime import datetime
 
-__version__ = "6.0.1"
+__version__ = "6.1.0"
 __current_year__ = datetime.now().year

--- a/src/sot/clean/agents.py
+++ b/src/sot/clean/agents.py
@@ -1,0 +1,162 @@
+"""Cache locations for coding agents.
+
+Cache paths are templates anchored to a named root, e.g.
+``"{xdg_cache}/opencode"``. Roots are resolved at scan time from the
+environment, falling back to the platform default when the variable is unset,
+so a machine with a relocated cache directory is still cleaned correctly.
+
+Entries for every platform live side by side -- the ones that don't apply
+simply won't exist on disk and get filtered out before anything is shown.
+
+Only caches, logs and scratch directories belong here. Conversation history,
+sessions, credentials and config are deliberately left out, as is anything the
+agent needs to keep running:
+
+* ``~/.claude/projects`` holds the session transcripts ``claude --resume``
+  reads.
+* ``~/.local/share/claude/versions`` holds the installed binaries, including
+  the one currently executing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Mapping, NamedTuple
+
+
+class CacheRoot(NamedTuple):
+    """A base directory that cache paths are anchored to.
+
+    ``env`` overrides ``default`` when set. A root with no ``default`` only
+    exists when its variable is set -- paths anchored to it are skipped
+    otherwise.
+    """
+
+    env: str | None
+    default: str | None
+
+
+class AgentCache(NamedTuple):
+    """A coding agent and the cache paths it leaves behind."""
+
+    name: str
+    description: str
+    paths: tuple[str, ...]
+
+
+# Defaults are relative to the user's home directory.
+CACHE_ROOTS: dict[str, CacheRoot] = {
+    "home": CacheRoot(None, ""),
+    # XDG base directory spec, honoured by opencode among others.
+    "xdg_cache": CacheRoot("XDG_CACHE_HOME", ".cache"),
+    "xdg_data": CacheRoot("XDG_DATA_HOME", ".local/share"),
+    "xdg_config": CacheRoot("XDG_CONFIG_HOME", ".config"),
+    # Claude Code relocates its whole state directory with this.
+    "claude_config": CacheRoot("CLAUDE_CONFIG_DIR", ".claude"),
+    # macOS.
+    "mac_caches": CacheRoot(None, "Library/Caches"),
+    "mac_app_support": CacheRoot(None, "Library/Application Support"),
+    # Windows.
+    "appdata": CacheRoot("APPDATA", "AppData/Roaming"),
+    "localappdata": CacheRoot("LOCALAPPDATA", "AppData/Local"),
+    # VS Code portable mode keeps user data alongside the app instead.
+    "vscode_portable": CacheRoot("VSCODE_PORTABLE", None),
+}
+
+
+def resolve_roots(environ: Mapping[str, str] | None = None) -> dict[str, Path]:
+    """Resolve every cache root against the environment.
+
+    ``sot`` inherits the invoking shell's environment, so exported overrides
+    are picked up without shelling out. Roots whose variable is unset and that
+    have no default are omitted.
+    """
+    env = os.environ if environ is None else environ
+    home = Path.home()
+    roots = {}
+
+    for name, root in CACHE_ROOTS.items():
+        value = env.get(root.env, "").strip() if root.env else ""
+        if value:
+            roots[name] = Path(value).expanduser()
+        elif root.default is not None:
+            roots[name] = home / root.default
+
+    return roots
+
+
+# VS Code style editors that host extension-based agents, in the per-platform
+# locations they keep extension state under.
+_EDITOR_GLOBAL_STORAGE = tuple(
+    f"{{{root}}}/{editor}/User/globalStorage"
+    for root in ("mac_app_support", "xdg_config", "appdata")
+    for editor in ("Code", "Cursor", "VSCodium")
+) + ("{vscode_portable}/user-data/User/globalStorage",)
+
+_KILO_PATHS = ("{home}/.kilocode/cache",) + tuple(
+    f"{storage}/kilocode.kilo-code/{subdir}"
+    for storage in _EDITOR_GLOBAL_STORAGE
+    for subdir in ("cache", "checkpoints")
+)
+
+
+CODING_AGENTS: tuple[AgentCache, ...] = (
+    AgentCache(
+        name="Claude Cache",
+        description="Claude Code caches, debug logs and shell snapshots",
+        paths=(
+            "{claude_config}/cache",
+            "{claude_config}/paste-cache",
+            "{claude_config}/debug",
+            "{claude_config}/shell-snapshots",
+            "{claude_config}/session-env",
+            "{claude_config}/statsig",
+            "{xdg_cache}/claude",
+            "{mac_caches}/claude-cli-nodejs",
+        ),
+    ),
+    AgentCache(
+        name="pi Cache",
+        description="pi agent cache and logs",
+        paths=(
+            "{home}/.pi/cache",
+            "{home}/.pi/logs",
+            "{xdg_cache}/pi",
+        ),
+    ),
+    AgentCache(
+        name="opencode Cache",
+        description="opencode cache and logs",
+        paths=(
+            "{xdg_cache}/opencode",
+            "{xdg_data}/opencode/cache",
+            "{xdg_data}/opencode/log",
+            "{appdata}/opencode/cache",
+        ),
+    ),
+    AgentCache(
+        name="Kilo Cache",
+        description="Kilo Code cache and checkpoints",
+        paths=_KILO_PATHS,
+    ),
+)
+
+
+def agent_paths(
+    agent: AgentCache, roots: Mapping[str, Path] | None = None
+) -> list[Path]:
+    """Expand an agent's templates against the resolved roots.
+
+    Paths anchored to a root that isn't available are skipped.
+    """
+    resolved = resolve_roots() if roots is None else roots
+    paths = []
+
+    for template in agent.paths:
+        try:
+            paths.append(Path(template.format(**resolved)))
+        except KeyError:
+            continue
+
+    return paths

--- a/src/sot/clean/cli.py
+++ b/src/sot/clean/cli.py
@@ -14,6 +14,8 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 from rich.text import Text
 
+from .agents import CODING_AGENTS, agent_paths, resolve_roots
+
 
 class CleanTarget(NamedTuple):
     """Represents a cleaning target with metadata."""
@@ -51,6 +53,30 @@ def _sizeof_fmt(num: int | float, suffix: str = "B") -> str:
             return f"{num:3.1f}{unit}{suffix}"
         num /= 1024.0
     return f"{num:.1f}P{suffix}"
+
+
+def _get_coding_agent_targets() -> list[CleanTarget]:
+    """Get cleaning targets for coding agent caches.
+
+    Only agents with at least one existing cache path are returned, so the
+    table stays limited to the agents actually installed on this machine.
+    See ``agents.py`` for the paths themselves.
+    """
+    roots = resolve_roots()
+    targets = []
+
+    for agent in CODING_AGENTS:
+        found = [path for path in agent_paths(agent, roots) if path.exists()]
+        if found:
+            targets.append(
+                CleanTarget(
+                    name=agent.name,
+                    path=found,
+                    description=agent.description,
+                )
+            )
+
+    return targets
 
 
 def _get_macos_targets() -> list[CleanTarget]:
@@ -125,6 +151,8 @@ def _get_macos_targets() -> list[CleanTarget]:
 
     for name, path, desc in browser_paths:
         targets.append(CleanTarget(name=name, path=path, description=desc))
+
+    targets.extend(_get_coding_agent_targets())
 
     return targets
 
@@ -212,6 +240,8 @@ def _get_linux_targets() -> list[CleanTarget]:
     for name, path, desc in browser_paths:
         targets.append(CleanTarget(name=name, path=path, description=desc))
 
+    targets.extend(_get_coding_agent_targets())
+
     return targets
 
 
@@ -274,6 +304,8 @@ def _get_windows_targets() -> list[CleanTarget]:
 
     for name, path, desc in browser_paths:
         targets.append(CleanTarget(name=name, path=path, description=desc))
+
+    targets.extend(_get_coding_agent_targets())
 
     return targets
 

--- a/src/sot/clean/cli.py
+++ b/src/sot/clean/cli.py
@@ -27,6 +27,24 @@ class CleanTarget(NamedTuple):
     recursive: bool = True
 
 
+def _is_elevated() -> bool:
+    """Whether this process can touch targets that need admin rights.
+
+    ``geteuid`` is POSIX only, so Windows is asked through the shell API
+    instead. Anything that fails to answer counts as unprivileged -- the
+    targets are then skipped rather than attempted and half completed.
+    """
+    if hasattr(os, "geteuid"):
+        return os.geteuid() == 0
+
+    try:
+        import ctypes
+
+        return bool(getattr(ctypes, "windll").shell32.IsUserAnAdmin())
+    except (AttributeError, OSError):
+        return False
+
+
 def _get_size(path: Path) -> int:
     """Calculate total size of a path (file or directory)."""
     try:
@@ -108,6 +126,19 @@ def _get_macos_targets() -> list[CleanTarget]:
             name="System Logs",
             path=Path("/var/log"),
             description="System log files",
+            requires_sudo=True,
+        ),
+        # Leftover macOS update payload, routinely 10GB+. The data volume path
+        # is the modern layout; the root one covers pre-Catalina installs.
+        # A small "Locked Files" stub inside is SIP protected and survives even
+        # under sudo -- it gets skipped with a warning like any other failure.
+        CleanTarget(
+            name="macOS Install Data",
+            path=[
+                Path("/System/Volumes/Data/macOS Install Data"),
+                Path("/macOS Install Data"),
+            ],
+            description="Leftover macOS installer payload",
             requires_sudo=True,
         ),
         CleanTarget(
@@ -391,8 +422,12 @@ def _clean_path(path: Path, console: Console) -> int:
         return 0
 
 
-def _clean_targets(results: dict, console: Console) -> int:
-    """Clean the targets and return total bytes freed."""
+def _clean_targets(results: dict, console: Console, elevated: bool) -> int:
+    """Clean the targets and return total bytes freed.
+
+    Targets flagged ``requires_sudo`` are only attempted when running with
+    the privileges to do so; otherwise they are reported and left alone.
+    """
     total_freed = 0
     targets_to_clean = [r for r in results.values() if r["exists"] and r["size"] > 0]
 
@@ -406,7 +441,7 @@ def _clean_targets(results: dict, console: Console) -> int:
         for result in targets_to_clean:
             target = result["target"]
 
-            if target.requires_sudo:
+            if target.requires_sudo and not elevated:
                 console.print(
                     f"  [yellow]⚠[/yellow]  Skipping {target.name} (requires sudo)"
                 )
@@ -446,6 +481,10 @@ def clean_command(args) -> int:
     }.get(system, system)
 
     console.print(f"📍 Detected OS: [bright_green]{os_name}[/]")
+
+    elevated = _is_elevated()
+    if elevated:
+        console.print("🔑 Running elevated: [bright_green]sudo targets included[/]")
     console.print()
 
     # Get targets
@@ -516,13 +555,14 @@ def clean_command(args) -> int:
 
     summary.add_row("Total cleanable:", f"[bright_green]{_sizeof_fmt(total_size)}[/]")
     if sudo_size > 0:
+        note = "" if elevated else " [dim](will be skipped)[/]"
         summary.add_row(
             "Requires sudo:",
-            f"[yellow]{_sizeof_fmt(sudo_size)}[/] [dim](will be skipped)[/]",
+            f"[yellow]{_sizeof_fmt(sudo_size)}[/]{note}",
         )
     summary.add_row(
         "Can clean now:",
-        f"[bright_cyan]{_sizeof_fmt(total_size - sudo_size)}[/]",
+        f"[bright_cyan]{_sizeof_fmt(total_size if elevated else total_size - sudo_size)}[/]",
     )
 
     console.print(Panel(summary, title="Summary", border_style="green"))
@@ -534,7 +574,7 @@ def clean_command(args) -> int:
         return 0
 
     # Confirmation
-    if sudo_size > 0:
+    if sudo_size > 0 and not elevated:
         console.print(
             "[yellow]⚠[/yellow]  Items requiring sudo will be skipped. "
             "Run with sudo to clean them."
@@ -556,7 +596,7 @@ def clean_command(args) -> int:
 
     # Clean
     console.print("🧹 Cleaning...")
-    freed = _clean_targets(results, console)
+    freed = _clean_targets(results, console, elevated)
 
     console.print()
 

--- a/tests/test_clean_agents.py
+++ b/tests/test_clean_agents.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from sot.clean import agents
+
+
+def test_roots_fall_back_to_home_defaults():
+    roots = agents.resolve_roots({})
+    home = Path.home()
+    assert roots["home"] == home
+    assert roots["xdg_cache"] == home / ".cache"
+    assert roots["claude_config"] == home / ".claude"
+    # No default and no variable set, so the root is unavailable.
+    assert "vscode_portable" not in roots
+
+
+def test_env_overrides_root():
+    roots = agents.resolve_roots({"CLAUDE_CONFIG_DIR": "/data/claude"})
+    assert roots["claude_config"] == Path("/data/claude")
+    # Unrelated roots keep their defaults.
+    assert roots["xdg_cache"] == Path.home() / ".cache"
+
+
+def test_blank_env_var_is_ignored():
+    # An exported-but-empty variable must not resolve to the filesystem root.
+    roots = agents.resolve_roots({"XDG_CACHE_HOME": "   "})
+    assert roots["xdg_cache"] == Path.home() / ".cache"
+
+
+def test_agent_paths_expand_against_roots():
+    roots = agents.resolve_roots({"XDG_CACHE_HOME": "/scratch"})
+    opencode = next(a for a in agents.CODING_AGENTS if a.name == "opencode Cache")
+    assert Path("/scratch/opencode") in agents.agent_paths(opencode, roots)
+
+
+def test_paths_needing_missing_root_are_skipped():
+    kilo = next(a for a in agents.CODING_AGENTS if a.name == "Kilo Cache")
+    without = agents.agent_paths(kilo, agents.resolve_roots({}))
+    with_portable = agents.agent_paths(
+        kilo, agents.resolve_roots({"VSCODE_PORTABLE": "/opt/vscode"})
+    )
+    # The two portable-mode templates only expand once the variable is set.
+    assert len(with_portable) == len(without) + 2
+    assert not any("vscode" in str(p).lower() for p in without)
+
+
+def test_every_template_uses_a_known_root():
+    roots = agents.resolve_roots({})
+    known = set(agents.CACHE_ROOTS)
+    for agent in agents.CODING_AGENTS:
+        for template in agent.paths:
+            root = template.split("}", 1)[0].lstrip("{")
+            assert root in known, f"{agent.name}: unknown root {root!r}"
+        # Nothing may expand to a bare root, which would wipe the directory.
+        for path in agents.agent_paths(agent, roots):
+            assert path not in roots.values(), f"{agent.name}: {path} is a root"

--- a/tests/test_clean_cli.py
+++ b/tests/test_clean_cli.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from rich.console import Console
+
+from sot.clean import cli
+
+# Nothing under test cares about the output, so keep the suite quiet.
+QUIET = Console(quiet=True)
+
+
+def _payload(tmp_path: Path) -> Path:
+    """A directory holding one 4KB file, standing in for a real cache."""
+    path = tmp_path / "payload"
+    path.mkdir()
+    (path / "blob.bin").write_bytes(b"x" * 4096)
+    return path
+
+
+def _results(target: cli.CleanTarget, size: int) -> dict:
+    """The scan result shape ``_clean_targets`` consumes."""
+    return {target.name: {"target": target, "size": size, "exists": True}}
+
+
+def test_sudo_target_is_skipped_without_elevation(tmp_path):
+    payload = _payload(tmp_path)
+    target = cli.CleanTarget("Sudo Target", payload, "test", requires_sudo=True)
+
+    freed = cli._clean_targets(_results(target, 4096), QUIET, elevated=False)
+
+    assert freed == 0
+    assert (payload / "blob.bin").exists()
+
+
+def test_sudo_target_is_cleaned_when_elevated(tmp_path):
+    payload = _payload(tmp_path)
+    target = cli.CleanTarget("Sudo Target", payload, "test", requires_sudo=True)
+
+    freed = cli._clean_targets(_results(target, 4096), QUIET, elevated=True)
+
+    assert freed == 4096
+    # Contents go, the directory itself stays.
+    assert list(payload.iterdir()) == []
+    assert payload.is_dir()
+
+
+def test_plain_target_ignores_the_elevation_flag(tmp_path):
+    payload = _payload(tmp_path)
+    target = cli.CleanTarget("Plain Target", payload, "test")
+
+    freed = cli._clean_targets(_results(target, 4096), QUIET, elevated=False)
+
+    assert freed == 4096
+    assert list(payload.iterdir()) == []
+
+
+def test_is_elevated_follows_euid(monkeypatch):
+    monkeypatch.setattr(cli.os, "geteuid", lambda: 0, raising=False)
+    assert cli._is_elevated()
+
+    monkeypatch.setattr(cli.os, "geteuid", lambda: 501, raising=False)
+    assert not cli._is_elevated()
+
+
+def test_is_elevated_is_false_when_euid_is_unavailable(monkeypatch):
+    # Windows has no geteuid, and the shell API lookup fails off Windows.
+    # That must report unprivileged rather than raise.
+    monkeypatch.delattr(cli.os, "geteuid", raising=False)
+    assert not cli._is_elevated()
+
+
+def test_macos_targets_include_install_data():
+    target = next(t for t in cli._get_macos_targets() if t.name == "macOS Install Data")
+
+    assert target.requires_sudo
+    assert Path("/System/Volumes/Data/macOS Install Data") in target.path
+
+
+def test_no_target_points_at_a_bare_root():
+    # A target resolving to home or / would empty the whole directory.
+    forbidden = {Path.home(), Path("/")}
+    builders = (
+        cli._get_macos_targets,
+        cli._get_linux_targets,
+        cli._get_windows_targets,
+    )
+
+    for build in builders:
+        for target in build():
+            paths = target.path if isinstance(target.path, list) else [target.path]
+            for path in paths:
+                assert path not in forbidden, f"{target.name}: {path} is a root"


### PR DESCRIPTION
Coding agents pile up caches, debug logs and scratch dirs that `sot clean` didn't know about, so they never showed up in a scan. This adds Claude Code, pi, opencode and Kilo Code.

Paths live in `src/sot/clean/agents.py` as templates anchored to named roots (`{xdg_cache}/opencode`), resolved from the environment at scan time so a relocated cache directory still gets found. `CLAUDE_CONFIG_DIR`, the XDG vars, `APPDATA`/`LOCALAPPDATA` and `VSCODE_PORTABLE` are honoured, falling back to the platform default when unset. Roots with no default, like portable-mode VS Code, are skipped rather than expanding to something wrong.

An agent only shows up when at least one of its paths exists, so there are no rows for tools you haven't installed. Caches, logs and scratch dirs only: `~/.claude/projects` holds the transcripts `claude --resume` reads and `~/.local/share/claude/versions` holds the running binary, so both are left alone.

Check the resolved locations with `sot clean --dry-run` before deleting anything.